### PR TITLE
Fixes create_style error

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   geoserver:
-    image: oscarfonts/geoserver:2.17.4
+    image: oscarfonts/geoserver:2.19.0
     volumes:
       - ./geoserver:/var/local/geoserver
       - ../test:/tmp

--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -896,7 +896,6 @@ class Catalog:
         if not overwrite or style is None:
             headers = {
                 "Content-type": "application/xml",
-                "Accept": "application/xml"
             }
             xml = "<style><name>{0}</name><filename>{0}.sld"\
                   + "</filename></style>"
@@ -907,7 +906,6 @@ class Catalog:
                 raise UploadError(r.text)
         headers = {
             "Content-type": style.content_type,
-            "Accept": "application/xml"
         }
         body_href = style.body_href
         if raw:

--- a/test/data/c.sld
+++ b/test/data/c.sld
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.0.0">
+  <sld:NamedLayer>
+    <sld:Name>C</sld:Name>
+    <sld:UserStyle>
+      <sld:Name>c</sld:Name>
+      <sld:FeatureTypeStyle>
+        <sld:Name>C</sld:Name>
+        <sld:FeatureTypeName>Feature</sld:FeatureTypeName>
+        <sld:Rule>
+          <sld:RasterSymbolizer>
+            <sld:Geometry>
+              <ogc:PropertyName>geom</ogc:PropertyName>
+            </sld:Geometry>
+            <sld:ColorMap>
+              <sld:ColorMapEntry color="#FFFFFF" opacity="0.0" quantity="-3.0"/>
+              <sld:ColorMapEntry color="#FFFFFF" opacity="1.0" quantity="200.0" label="200.0"/>
+              <sld:ColorMapEntry color="#FFF573" opacity="1.0" quantity="500.0" label="500.0"/>
+              <sld:ColorMapEntry color="#FFE91E" opacity="1.0" quantity="800.0" label="800.0"/>
+              <sld:ColorMapEntry color="#FFA400" opacity="1.0" quantity="1100.0" label="1100.0"/>
+              <sld:ColorMapEntry color="#FA8000" opacity="1.0" quantity="1400.0" label="1400.0"/>
+              <sld:ColorMapEntry color="#F45C00" opacity="1.0" quantity="1700.0" label="1700.0"/>
+              <sld:ColorMapEntry color="#E53C00" opacity="1.0" quantity="2000.0" label="2000.0"/>
+              <sld:ColorMapEntry color="#C02E00" opacity="1.0" quantity="2300.0" label="2300.0"/>
+              <sld:ColorMapEntry color="#9E2700" opacity="1.0" quantity="2600.0" label="2600.0"/>
+              <sld:ColorMapEntry color="#7E2300" opacity="1.0" quantity="2900.0" label="2900.0"/>
+              <sld:ColorMapEntry color="#481501" opacity="1.0" quantity="3200.0" label="3200.0"/>
+            </sld:ColorMap>
+            <sld:ContrastEnhancement/>
+          </sld:RasterSymbolizer>
+        </sld:Rule>
+      </sld:FeatureTypeStyle>
+    </sld:UserStyle>
+  </sld:NamedLayer>
+</sld:StyledLayerDescriptor>

--- a/test/test_catalog/__init__.py
+++ b/test/test_catalog/__init__.py
@@ -15,7 +15,7 @@ DOCKER_MOUNT_FOLDER = '/tmp'
 BASE_PATH = os.path.dirname(os.path.dirname(__file__))
 
 # Test database parameters
-_HOST = "192.168.0.21"
+_HOST = "postgis"
 _PORT = "5432"
 _DB_TYPE = "postgis"
 _DATABASE = os.getenv("DATABASE", "gsconfig_test")

--- a/test/test_catalog/test_catalog_resource.py
+++ b/test/test_catalog/test_catalog_resource.py
@@ -30,3 +30,22 @@ class TestCatalogResource(TestCatalogBase):
         resource_name = "gsconfig_test_create_imagemosaic"
         resource = self.catalog.get_resource(resource_name, store=ds)
         print("Resource: {}".format(resource))
+
+    def test_create_style(self):
+        ws = self.workspace
+        sld_file_path = os.path.join(BASE_PATH, "data/c.sld")
+        with open(sld_file_path) as f:
+            style_name = os.path.basename(sld_file_path).replace('.sld', '')
+            style_format = 'sld10'
+            self.catalog.create_style(name=style_name,
+                                      data=f.read(),
+                                      overwrite=True,
+                                      workspace=ws,
+                                      style_format=style_format)
+
+            style = self.catalog.get_style(style_name, workspace=ws)
+
+            self.assertIsNotNone(style)
+            self.assertEqual(style.name, style_name)
+            self.assertEqual(style.style_format, style_format)
+


### PR DESCRIPTION
Fixes error in style creation reported by Michał Iwaniuk:

`scripts/raster_publishing/upload_style.py `

And after running for example:

`./upload_style.py -i /srv/web/data/style_templates/c.sld`

and if style "c" is not already loaded, we're getting:

```
Importing style definition from file /srv/web/data/style_templates/c.sld
Traceback (most recent call last):
  File "./upload_style.py", line 28, in <module>
    upload_style(args.input)
  File "./upload_style.py", line 19, in upload_style
    catalog.create_style(os.path.basename(sld_file_path).replace('.sld', ''), f.read(), overwrite=True)
  File "/srv/web/virtualenv3.8/lib/python3.8/site-packages/geoserver/catalog.py", line 907, in create_style
    raise UploadError(r.text)
geoserver.catalog.UploadError: No such style handler: format = application/xml
```

Explanation here:

[http://osgeo-org.1560.x6.nabble.com/JIRA-GEOS-9280-Uploading-of-SLD-from-GeoNode-fails-td5409889.html](http://osgeo-org.1560.x6.nabble.com/JIRA-GEOS-9280-Uploading-of-SLD-from-GeoNode-fails-td5409889.html)